### PR TITLE
Create a documents and topics scatter plot

### DIFF
--- a/top2vec/Top2Vec.py
+++ b/top2vec/Top2Vec.py
@@ -2118,3 +2118,86 @@ class Top2Vec:
                       height=400,
                       background_color=background_color).generate_from_frequencies(word_score_dict))
         plt.title("Topic " + str(topic_num), loc='left', fontsize=25, pad=20)
+
+    def generate_documents_plot(self, background_color="black", reduced=False):
+        """
+        Create a documents and topics scatter plot.
+
+        A documents and topics scatter plot will be generated and displayed.
+        Documents on the same topic display in the same color. 
+        On the plot, circles mean documents, and numbers mean the number of 
+        topic. 
+        Cautions: The plot should only be considered as approximate information
+        because it is a result of dimention reduction from 5D to 2D. And it could
+        be hard to distinguish for more than 20 topics. In this case, use the
+        reduced option.
+
+        Parameters
+        ----------
+        background_color : str (Optional, default='white')
+            Background color for the plot. Suggested options are:
+                * white
+                * black
+
+        reduced: bool (Optional, default False)
+            Original topics are used by default. If True the
+            reduced topics will be used.
+
+        Returns
+        -------
+        A matplotlib plot of documents and topics
+
+        """
+
+        if reduced:
+            self._validate_hierarchical_reduction()
+            topic_vectors = self.topic_vectors_reduced
+            topic_sizes, topic_nums = self.get_topic_sizes(reduced=True)
+            doc_topics = self.doc_top_reduced
+            doc_dist = self.doc_dist_reduced
+        else:
+            topic_vectors = self.topic_vectors
+            topic_sizes, topic_nums = self.get_topic_sizes()
+            doc_topics = self.doc_top
+            doc_dist = self.doc_dist
+
+        if len(topic_nums) <= 12:
+            cmap = 'Paired'
+        elif len(topic_nums) <= 20:
+            cmap = 'tab20'
+        else:
+            cmap = 'hsv'
+
+        # Args for UMAP. Same as current args except n_components to plot graph
+        umap_args_for_plot = self.umap_args.copy()
+        umap_args_for_plot.update({'n_components': 2,})
+
+        # Dimension reduction
+        document_vectors = self._get_document_vectors()
+        topic_vectors = topic_vectors
+        umap_model = umap.UMAP(**umap_args_for_plot, random_state=42).fit(document_vectors)  #  + self.topic_words
+        document_vectors_2d = umap_model.embedding_  # same as umap_model.transform(self._get_document_vectors())
+        topic_vectors_2d = umap_model.transform(topic_vectors)
+
+        ## Draw a graph
+        fig = plt.figure(figsize=(16, 12))
+        ax = fig.subplots()
+        ax.axis("off")
+        fig.set_facecolor(background_color)
+
+        # Draw document vectors
+        ax.scatter(*document_vectors_2d.T, 
+                    s=20, c=doc_topics, cmap=cmap, alpha=0.7,  # linewidth=1, 
+                    )
+
+        # Draw topic vectors
+        ax.scatter(*topic_vectors_2d.T, 
+                    s=200, linewidth=2, c=topic_nums, cmap=cmap, alpha=0.4,
+                    )
+        for topic_num, topic_vector_2d in zip(topic_nums, topic_vectors_2d):
+            ax.annotate(topic_num, 
+                        topic_vector_2d,
+                        horizontalalignment='center',
+                        verticalalignment='center',
+                        size=10,
+                        color='white') 

--- a/top2vec/Top2Vec.py
+++ b/top2vec/Top2Vec.py
@@ -179,7 +179,9 @@ class Top2Vec:
                  workers=None,
                  tokenizer=None,
                  use_embedding_model_tokenizer=False,
-                 verbose=True):
+                 verbose=True,
+                 umap_args=None,
+                 hdbscan_args=None):
 
         if verbose:
             logger.setLevel(logging.DEBUG)
@@ -340,15 +342,19 @@ class Top2Vec:
 
         # create 5D embeddings of documents
         logger.info('Creating lower dimension embedding of documents')
-        umap_model = umap.UMAP(n_neighbors=15,
-                               n_components=5,
-                               metric='cosine').fit(self._get_document_vectors(norm=False))
+        
+        self.umap_args = {'n_neighbors': 15,
+                            'n_components': 5,
+                            'metric': 'cosine'} if umap_args is not None else umap_args
+        umap_model = umap.UMAP(**self.umap_args).fit(self._get_document_vectors(norm=False))
 
         # find dense areas of document vectors
         logger.info('Finding dense areas of documents')
-        cluster = hdbscan.HDBSCAN(min_cluster_size=15,
-                                  metric='euclidean',
-                                  cluster_selection_method='eom').fit(umap_model.embedding_)
+        
+        self.hdbscan_args = {'min_cluster_size': 15,
+                            'metric': 'euclidean',
+                            'cluster_selection_method': 'eom'} if hdbscan_args is not None else hdbscan_args
+        cluster = hdbscan.HDBSCAN(**self.hdbscan_args).fit(umap_model.embedding_)
 
         # calculate topic vectors from dense areas of documents
         logger.info('Finding topics')


### PR DESCRIPTION
Hello, Angelov.
I made a function for simple documents and topics scatter plot.
- Documents on the same topic display in the same color. 
- On the plot, circles mean documents, and numbers mean the number of topic. 

Of course, to draw it on 2D,  dimention reduction by umap is needed. So some distortion could be exist. 
Nevertheless, it can help a lot to discover the outlier or check the status of reduced topics.

Thanks.
Hangil Kim