### PR TITLE
pin gensim to fix error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.20.0
 pandas
-gensim
+gensim==3.8.3
 umap-learn>=0.5.1
 hdbscan>=0.8.27
 wordcloud


### PR DESCRIPTION
Gensim recently updated it's major version which breaks this package since the major version is not pinned in requirements. Refer here for someone else who faced this issue https://stackoverflow.com/questions/66891439/top2vec-error-keyedvectors-object-has-no-attribute-vectors-docs