### PR TITLE
Add PCA to Top2Vec

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,3 +418,15 @@ for word, score in zip(words, word_scores):
     facility 0.4325
     propulsion 0.4251
     aerospace 0.4226
+
+### Dimensionality Reduction
+
+By default Top2Vec will use UMAP, which can be configured using the `umap_args` parameter. The default value is:
+
+    {"n_neighbors": 15, "n_components": 5, "metric": "cosine"}
+
+If you would like to use PCA instead, you can use the `pca_args` parameter.
+
+```
+model = Top2Vec(documents, pca_args={"n_components": "mle", "svd_solver": "full"})
+```

--- a/top2vec/tests/test_top2vec.py
+++ b/top2vec/tests/test_top2vec.py
@@ -21,6 +21,9 @@ top2vec_no_docs = Top2Vec(documents=newsgroups_documents, keep_documents=False, 
 # train top2vec model with corpus_file
 top2vec_corpus_file = Top2Vec(documents=newsgroups_documents, use_corpus_file=True, speed="fast-learn", workers=8)
 
+# train top2vec model with corpus_file using PCA
+top2vec_pca = Top2Vec(documents=newsgroups_documents, use_corpus_file=True, speed="fast-learn", workers=8, pca_args={"n_components": "mle", "svd_solver": "full"})
+
 # test USE
 top2vec_use = Top2Vec(documents=newsgroups_documents, embedding_model='universal-sentence-encoder')
 
@@ -42,7 +45,7 @@ top2vec_transformer_model_embedding = Top2Vec(documents=newsgroups_documents,
                                               embedding_model='distiluse-base-multilingual-cased',
                                               use_embedding_model_tokenizer=True)
 
-models = [top2vec, top2vec_docids, top2vec_no_docs, top2vec_corpus_file,
+models = [top2vec, top2vec_docids, top2vec_no_docs, top2vec_corpus_file, top2vec_pca,
           top2vec_use, top2vec_use_multilang, top2vec_transformer_multilang,
           top2vec_use_model_embedding, top2vec_transformer_model_embedding]
 


### PR DESCRIPTION
Hello

I've noticed that for some datasets PCA performs better than UMAP. 
I've added an option to use PCA instead of UMAP, added to the models in the tests, and added some information about dim reduction to the `README`. I didn't see any notes about contributing in the project, let me know if there is something else I need to do.

Thanks