### PR TITLE
add wordcloud font

### DIFF
--- a/top2vec/Top2Vec.py
+++ b/top2vec/Top2Vec.py
@@ -2373,7 +2373,7 @@ class Top2Vec:
         else:
             return doc_scores, doc_ids
 
-    def generate_topic_wordcloud(self, topic_num, background_color="black", reduced=False):
+    def generate_topic_wordcloud(self, topic_num, background_color="black", font_path=None, reduced=False):
         """
         Create a word cloud for a topic.
 
@@ -2419,5 +2419,6 @@ class Top2Vec:
         plt.imshow(
             WordCloud(width=1600,
                       height=400,
+                      font_path=font_path,
                       background_color=background_color).generate_from_frequencies(word_score_dict))
         plt.title("Topic " + str(topic_num), loc='left', fontsize=25, pad=20)


### PR DESCRIPTION
add `font_path` to `generate_topic_wordcloud` so that more fonts can be supported. otherwise, non-alphabet language can not display.