### PR TITLE
Port search_documents_by_keywords to C-Top2Vec

### DIFF
--- a/top2vec/embedding.py
+++ b/top2vec/embedding.py
@@ -113,9 +113,11 @@ def sliding_window_average(document_token_embeddings, document_tokens, window_si
     # Store the averaged embeddings
     averaged_embeddings = []
     chunk_tokens = []
+    multi_document_labels = []
 
     # Iterate over each document
-    for doc, tokens in tqdm(zip(document_token_embeddings, document_tokens)):
+    for ind, (doc, tokens) in tqdm(enumerate(
+            zip(document_token_embeddings, document_tokens))):
         doc_averages = []
 
         # Slide the window over the document with the specified stride
@@ -137,11 +139,12 @@ def sliding_window_average(document_token_embeddings, document_tokens, window_si
             chunk_tokens.append(" ".join(tokens[start:end]))
 
         averaged_embeddings.append(doc_averages)
+        multi_document_labels.extend([ind] * len(doc_averages))
 
     averaged_embeddings = np.vstack(averaged_embeddings)
     averaged_embeddings = normalize(averaged_embeddings)
 
-    return averaged_embeddings, chunk_tokens
+    return averaged_embeddings, chunk_tokens, multi_document_labels
 
 
 def average_adjacent_tokens(token_embeddings, window_size):


### PR DESCRIPTION
This PR enables support for searching documents by keyword for C-Top2Vec models.

The first commit adds a `Top2Vec` parameter named `combine_ngram_vocab` to add both single words and n-grams to the phrase embeddings. If this is enabled, then the original behavior described in #364 is restored. The motivation is we don't use the top topic words (and if we do, we are manually selecting representative words/phrases), but we do want to be able to search by both word or phrase.

The second commit enables `search_documents_by_keywords()` to work with C-Top2Vec. This relies on the same `self.document_vectors` member variable as original Top2Vec, which here is the multi-vector document representation. Since the splitting of the original documents is a byproduct of the sliding window average, I have introduced another member `self.multi_document_labels` to maintain the mapping of each multi-document vector to the original vector.